### PR TITLE
118 feat backend improve error handling on failed request to ordinator api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,6 +1610,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/imperium/Cargo.toml
+++ b/imperium/Cargo.toml
@@ -21,3 +21,4 @@ strum = "*"
 tokio = { version = "*", features = ["full"] }
 toml = "*"
 tracing = "*"
+url = "2.5.4"


### PR DESCRIPTION
With this implementation a failed request will be formatted instead of being returned as json. An example is shown below.

```
Imperium did not complete the Request

Caused by:
    0: Could not send request
    1: error sending request for url (http://<url>/<endpoint>)
    2: client error (Connect)
    3: tcp connect error: Connection refused (os error 111)
    4: Connection refused (os error 111)
```